### PR TITLE
Update meta descriptions for top 10,000 users, organizations, and repositories

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %title= content_for(:title) || page_title
     %link{ rel: 'shortcut icon', href: '/favicon.ico' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
-    %meta{ name: 'description', content: content_for?(:description) ? yield(:description) : 'Gitstar Ranking is a GitHub star ranking. You can see top 1000 users, organizations and repositories. Find your favorite user. See what is your rank.' }
+    %meta{ name: 'description', content: content_for?(:description) ? yield(:description) : 'Gitstar Ranking is a GitHub star ranking. You can see top 10,000 users, organizations and repositories. Find your favorite user. See what is your rank.' }
     %meta{ name: 'keywords', content: 'GitHub, Star, Gitstar, Ranking' }
     - if content_for?(:canonical)
       %link{ rel: 'canonical', href: yield(:canonical) }

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -1,5 +1,5 @@
 - prepend_page_title 'Organizations Ranking'
-- provide :description, "See the top 1000 GitHub organizations on GitHub Ranking."
+- provide :description, "See the top 10,000 GitHub organizations on GitHub Ranking."
 = render 'shared/pagination_link', max_page: pagination_limit, url: organizations_url
 
 = render_flash :notice

--- a/app/views/repositories/index.html.haml
+++ b/app/views/repositories/index.html.haml
@@ -1,5 +1,5 @@
 - prepend_page_title 'Repositories Ranking'
-- provide :description, "See the top 1000 GitHub repositories on GitHub Ranking."
+- provide :description, "See the top 10,000 GitHub repositories on GitHub Ranking."
 = render 'shared/pagination_link', max_page: pagination_limit, url: repositories_url
 
 = render_flash :notice

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,5 @@
 - prepend_page_title 'Users Ranking'
-- provide :description, 'See the top 1000 GitHub users on GitHub Ranking.'
+- provide :description, 'See the top 10,000 GitHub users on GitHub Ranking.'
 = render 'shared/pagination_link', max_page: pagination_limit, url: users_url
 
 = render_flash :notice


### PR DESCRIPTION
 This PR updates meta description from "top 1000" to "top 10,000" to reflect the current pagination limit (100 pages × 100 entries).